### PR TITLE
Remove the views when they are not needed

### DIFF
--- a/app/src/main/java/com/gabm/tapandturn/services/ServiceRotationControlService.java
+++ b/app/src/main/java/com/gabm/tapandturn/services/ServiceRotationControlService.java
@@ -51,17 +51,18 @@ public class ServiceRotationControlService extends Service implements PhysicalOr
             orientationButtonOverlay.show(oldScreenOrientation, newScreenOrientation);
             handlerScreenOrientation = newScreenOrientation;
         }
-        else
+        else {
             orientationButtonOverlay.hide();
-
+            screenRotatorOverlay.removeView();
+        }
     }
 
     @Override
     public void onClick(View view) {
         orientationButtonOverlay.hide();
+        screenRotatorOverlay.removeView();
         if (handlerScreenOrientation == physicalOrientationSensor.getCurScreenOrientation()) {
             screenRotatorOverlay.changeOrientation(handlerScreenOrientation);
-
         }
 
     }
@@ -93,6 +94,10 @@ public class ServiceRotationControlService extends Service implements PhysicalOr
 
     @Override
     public void onDestroy() {
+        Log.i("LocalService", "Service stopped");
+
+        screenRotatorOverlay.removeView();
+        orientationButtonOverlay.hide();
 
         physicalOrientationSensor.disable();
 

--- a/app/src/main/java/com/gabm/tapandturn/ui/OrientationButtonOverlay.java
+++ b/app/src/main/java/com/gabm/tapandturn/ui/OrientationButtonOverlay.java
@@ -52,7 +52,7 @@ public class OrientationButtonOverlay {
 
     public void show(int oldOrientation, int newOrientation) {
         if (imageButton.getParent() != null)
-            hide();
+            curWindowManager.removeView(imageButton);
 
         int iconSizeDP = curPreferences.getInt("IconSize", 40);
         final int iconSizePx = (int)(curContext.getResources().getDisplayMetrics().density * iconSizeDP + 0.5);

--- a/app/src/main/java/com/gabm/tapandturn/ui/ScreenRotatorOverlay.java
+++ b/app/src/main/java/com/gabm/tapandturn/ui/ScreenRotatorOverlay.java
@@ -38,4 +38,10 @@ public class ScreenRotatorOverlay {
 
         currentlySetScreenOrientation = orientation;
     }
+
+    // Immidiately removes the current view
+    public void removeView() {
+        if (dummyLayout.getParent() != null)
+            curWindowManager.removeView(dummyLayout);
+    }
 }


### PR DESCRIPTION
Fixes #3.

Thanks for making this app, it is very useful! I was running into the problem in #3, and because I came across the same problem while making Red Moon, I decided to make a PR.

Android only blocks sensitive actions, when an app is currently drawing
over the screen. By removing the views when they are not needed, users
will rarely be inconvenienced by this, since the icon is ussualy not in
view. If it is in view and they try to install something, simply waiting
till the icon dissapears will fix their issue.

Furthermore I noticed that the views weren't being removed after stopping the service. This meant that stopping the service wasn't a workaround for #3, this PR also fixes that.

I have tested this for a bit and it works on my device, let me know if you have any comments.