### PR TITLE
Fix Issue #52

### DIFF
--- a/app/src/main/java/com/gabm/tapandturn/services/RotationControlService.java
+++ b/app/src/main/java/com/gabm/tapandturn/services/RotationControlService.java
@@ -1,6 +1,7 @@
 package com.gabm.tapandturn.services;
 
 import android.app.AlarmManager;
+import android.app.KeyguardManager;
 import android.app.Notification;
 import android.app.NotificationManager;
 import android.app.PendingIntent;
@@ -64,6 +65,7 @@ public class RotationControlService extends Service implements PhysicalOrientati
     private BroadcastReceiver screenOffBroadcastReceiver = new BroadcastReceiver() {
         @Override
         public void onReceive(Context context, Intent intent) {
+            KeyguardManager kgs = context.getSystemService(Context.KEYGUARD_SERVICE);
             if (intent.getAction().equals(Intent.ACTION_SCREEN_OFF)) {
                 if (isActive) {
                     physicalOrientationSensor.disable();
@@ -73,7 +75,9 @@ public class RotationControlService extends Service implements PhysicalOrientati
                         screenRotatorOverlay.forceOrientation(WindowManagerSensor.queryDefaultOrientation(windowManager, getResources().getConfiguration()));
 
                 }
-            } else if (intent.getAction().equals(Intent.ACTION_USER_PRESENT)) {
+            } else if (intent.getAction().equals(Intent.ACTION_SCREEN_ON) && !kgm.isDeviceLocked() || 
+                       intent.getAction().equals(Intent.ACTION_USER_PRESENT))
+            {
                 if (isActive) {
                     physicalOrientationSensor.enable();
                 }

--- a/app/src/main/java/com/gabm/tapandturn/services/RotationControlService.java
+++ b/app/src/main/java/com/gabm/tapandturn/services/RotationControlService.java
@@ -65,7 +65,7 @@ public class RotationControlService extends Service implements PhysicalOrientati
     private BroadcastReceiver screenOffBroadcastReceiver = new BroadcastReceiver() {
         @Override
         public void onReceive(Context context, Intent intent) {
-            KeyguardManager kgs = context.getSystemService(Context.KEYGUARD_SERVICE);
+            KeyguardManager kgm = (KeyguardManager) context.getSystemService(Context.KEYGUARD_SERVICE);
             if (intent.getAction().equals(Intent.ACTION_SCREEN_OFF)) {
                 if (isActive) {
                     physicalOrientationSensor.disable();
@@ -75,7 +75,7 @@ public class RotationControlService extends Service implements PhysicalOrientati
                         screenRotatorOverlay.forceOrientation(WindowManagerSensor.queryDefaultOrientation(windowManager, getResources().getConfiguration()));
 
                 }
-            } else if (intent.getAction().equals(Intent.ACTION_SCREEN_ON) && !kgm.isDeviceLocked() || 
+            } else if (intent.getAction().equals(Intent.ACTION_SCREEN_ON) && !kgm.isKeyguardLocked() ||
                        intent.getAction().equals(Intent.ACTION_USER_PRESENT))
             {
                 if (isActive) {
@@ -92,6 +92,7 @@ public class RotationControlService extends Service implements PhysicalOrientati
 
         filter = new IntentFilter();
         filter.addAction(Intent.ACTION_SCREEN_OFF);
+        filter.addAction(Intent.ACTION_SCREEN_ON);
         filter.addAction(Intent.ACTION_USER_PRESENT);
 
         registerReceiver(screenOffBroadcastReceiver, filter);


### PR DESCRIPTION
Fix a bug where TapAndTurn running and active but shows no icon if the user does not unlock their device when the screen turns on.

Fixes https://github.com/gabm/TapAndTurn/issues/52